### PR TITLE
fix: adjust gradient animation to prevent overflow

### DIFF
--- a/src/components/HomepageGradient/style.scss
+++ b/src/components/HomepageGradient/style.scss
@@ -24,20 +24,20 @@
             will-change: transform;  
             backface-visibility: hidden;  
             position: absolute;
-            inset: 0;
+            inset: -10%;
             background:
                 radial-gradient(circle at 77% 51%,
                     var(--gradient-color-1) 0%,
-                    transparent 40%),
+                    transparent 45%),
                 radial-gradient(circle at 23% 72%,
                     var(--gradient-color-2) 0%,
-                    transparent 58%),
+                    transparent 63%),
                 radial-gradient(circle at 52% 50%,
                     var(--gradient-color-3) 0%,
-                    transparent 50%),
+                    transparent 55%),
                 radial-gradient(circle at 15% 40%,
                     var(--gradient-color-4) 0%,
-                    transparent 40%);
+                    transparent 45%);
             filter: blur(20px) brightness(1.1);
             mix-blend-mode: screen;
             transform-origin: center center;
@@ -113,22 +113,22 @@
 
 @keyframes gradient-move {
     0% {
-        transform: translate(0, 0) scale(1);
+        transform: translate(0, 0) scale(1.2);
     }
 
     25% {
-        transform: translate(-5%, 5%) scale(1.1);
+        transform: translate(-3%, 3%) scale(1.2);
     }
 
     50% {
-        transform: translate(5%, -5%) scale(1);
+        transform: translate(3%, -3%) scale(1.2);
     }
 
     75% {
-        transform: translate(-2%, -2%) scale(1.1);
+        transform: translate(-2%, -2%) scale(1.2);
     }
 
     100% {
-        transform: translate(0, 0) scale(1);
+        transform: translate(0, 0) scale(1.2);
     }
 }

--- a/src/components/HomepageGradient/style.scss
+++ b/src/components/HomepageGradient/style.scss
@@ -1,9 +1,9 @@
 .gradient-background {
     font-family: 'Gill Sans', 'Gill Sans MT', Calibri, 'Trebuchet MS', sans-serif;
-    --gradient-color-1: #c084fc;
-    --gradient-color-2: #818cf8;
-    --gradient-color-3: #34d399;
-    --gradient-color-4: #60a5fa;
+    --gradient-color-1: #FF0080;
+    --gradient-color-2: #7928CA;
+    --gradient-color-3: #00DFD8;
+    --gradient-color-4: #FF4D4D;
 
     position: relative;
     min-height: 100vh;
@@ -26,22 +26,24 @@
             position: absolute;
             inset: -10%;
             background:
-                radial-gradient(circle at 77% 51%,
+                radial-gradient(circle at 80% 40%,
                     var(--gradient-color-1) 0%,
-                    transparent 45%),
-                radial-gradient(circle at 23% 72%,
-                    var(--gradient-color-2) 0%,
-                    transparent 63%),
-                radial-gradient(circle at 52% 50%,
-                    var(--gradient-color-3) 0%,
                     transparent 55%),
-                radial-gradient(circle at 15% 40%,
+                radial-gradient(circle at 20% 75%,
+                    var(--gradient-color-2) 0%,
+                    transparent 65%),
+                radial-gradient(circle at 60% 25%,
+                    var(--gradient-color-3) 0%,
+                    transparent 50%),
+                radial-gradient(circle at 25% 35%,
                     var(--gradient-color-4) 0%,
-                    transparent 45%);
-            filter: blur(20px) brightness(1.1);
+                    transparent 60%);
+            filter: blur(24px) brightness(1.15);
             mix-blend-mode: screen;
             transform-origin: center center;
-            animation: gradient-move 25s cubic-bezier(0.42, 0, 0.58, 1) infinite;
+            animation: 
+                gradient-move 20s cubic-bezier(0.4, 0, 0.2, 1) infinite,
+                gradient-scale 15s ease-in-out infinite alternate;
         }
 
         // Add noise texture overlay
@@ -113,22 +115,36 @@
 
 @keyframes gradient-move {
     0% {
-        transform: translate(0, 0) scale(1.2);
+        transform: translate(0, 0) rotate(0deg);
     }
 
     25% {
-        transform: translate(-3%, 3%) scale(1.2);
+        transform: translate(-4%, 6%) rotate(2deg);
     }
 
     50% {
-        transform: translate(3%, -3%) scale(1.2);
+        transform: translate(4%, -4%) rotate(-2deg);
     }
 
     75% {
-        transform: translate(-2%, -2%) scale(1.2);
+        transform: translate(-3%, -3%) rotate(1deg);
     }
 
     100% {
-        transform: translate(0, 0) scale(1.2);
+        transform: translate(0, 0) rotate(0deg);
+    }
+}
+
+@keyframes gradient-scale {
+    0% {
+        transform: scale(1.2);
+    }
+
+    50% {
+        transform: scale(1.3);
+    }
+
+    100% {
+        transform: scale(1.2);
     }
 }

--- a/src/components/HomepageGradient/style.scss
+++ b/src/components/HomepageGradient/style.scss
@@ -113,22 +113,22 @@
 
 @keyframes gradient-move {
     0% {
-        transform: translate(0, 0) scale(1.2);
+        transform: translate(0, 0) scale(1);
     }
 
     25% {
-        transform: translate(-10%, 10%) scale(1.3);
+        transform: translate(-5%, 5%) scale(1.1);
     }
 
     50% {
-        transform: translate(10%, -10%) scale(1.1);
+        transform: translate(5%, -5%) scale(1);
     }
 
     75% {
-        transform: translate(-5%, -5%) scale(1.4);
+        transform: translate(-2%, -2%) scale(1.1);
     }
 
     100% {
-        transform: translate(0, 0) scale(1.2);
+        transform: translate(0, 0) scale(1);
     }
 }


### PR DESCRIPTION
## Description
This PR fixes the gradient overflow issue reported in #107 by adjusting the animation parameters.

### Changes
- Reduced scale values in gradient animation from 1.1-1.4 to 1.0-1.1
- Adjusted translate values for smoother movement
- Set consistent scale values at start and end points for seamless looping

### Testing
- Verified gradient stays within screen bounds
- Checked animation smoothness
- Tested in both light and dark modes

Fixes #107

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **스타일**
  - 홈페이지에서 사용하는 그라데이션 색상과 애니메이션 효과를 개선하여, 보다 부드럽고 자연스러운 전환 효과를 경험할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->